### PR TITLE
Patch habitat page links

### DIFF
--- a/_site/old-mbbs/allhabitats.html
+++ b/_site/old-mbbs/allhabitats.html
@@ -5,14 +5,6 @@
 
 <style type="text/css" media="screen,print">
 
-<!--
-
-@import
-
-"http://www.unc.edu/~rhwiley/mbbs/style_mbbs.css";
-
--->
-
 </style>
 
 </head>
@@ -31,10 +23,6 @@
 
 </center>
 
-<p>              
-   
-<img src="http://www.unc.edu/~rhwiley/gifs/blackpixel.GIF" height=1 width=100%>   
-   
 <p>
 
 
@@ -54,17 +42,13 @@ habitat=MM,SP,BB,BB,MM,BO,BB(O),OO,BB,OO,MB,HH,BM,BM(W),B(O)B(O),OS,OO,OB(OW),HO
 
 </blockquote>              
    
-This list includes 20 items separated by <b>commas</b> and ending with a <b>semicolon</b>. &nbsp;  Each item consists of <b>two letters</b> -- the primary habitat codes directly to the left and right within 50 m (yards) of each stop -- see <a href="http://www.unc.edu/~rhwiley/mbbs/habitatcodes.html" target="_blank">the instructions for habitat codes</a>.  
+This list includes 20 items separated by <b>commas</b> and ending with a <b>semicolon</b>. &nbsp;  Each item consists of <b>two letters</b> -- the primary habitat codes directly to the left and right within 50 m (yards) of each stop -- see <a href="habitatcodes.html" target="_blank">the instructions for habitat codes</a>.  
 
 <p>              
    
 Any (optional) secondary (or tertiary) habitat codes are placed in parentheses following the corresponding primary habitat code.
 
 <p>              
-   
-<img src="http://www.unc.edu/~rhwiley/gifs/blackpixel.GIF" height=1 width=100%>   
-   
-<p>
 
 <center>
 
@@ -146,10 +130,6 @@ Estimating the proportions of all habitats within hearing range of a stop would 
 
 <p>              
 
-<img src="http://www.unc.edu/~rhwiley/gifs/blackpixel.GIF" height=1   
-width=100%>   
-   
-<p>
 
 </td></tr>
 

--- a/_site/old-mbbs/allhabitats.html
+++ b/_site/old-mbbs/allhabitats.html
@@ -58,10 +58,6 @@ Any (optional) secondary (or tertiary) habitat codes are placed in parentheses f
 
 <p>
 
-See the <a href="http://www.unc.edu/~rhwiley/mbbs/#ebird" target="_blank">basic instructions for the Comments box</a>.
-
-<p>
-
 The draconian instructions about standardized punctuation make it far easier for anyone to download and analyze our surveys.  &nbsp; Provided the format of the punctuation is exactly standardized, a simple computer program can parse the Comments box to recover all the pertinent information.  &nbsp; Otherwise, it would be hell on wheels to make a computer figure out everybody's individual preferences for formatting! &nbsp; So, with that thought in mind ...
 
 <p>

--- a/old-mbbs/allhabitats.html
+++ b/old-mbbs/allhabitats.html
@@ -31,10 +31,6 @@
 
 </center>
 
-<p>              
-   
-<img src="http://www.unc.edu/~rhwiley/gifs/blackpixel.GIF" height=1 width=100%>   
-   
 <p>
 
 
@@ -54,17 +50,13 @@ habitat=MM,SP,BB,BB,MM,BO,BB(O),OO,BB,OO,MB,HH,BM,BM(W),B(O)B(O),OS,OO,OB(OW),HO
 
 </blockquote>              
    
-This list includes 20 items separated by <b>commas</b> and ending with a <b>semicolon</b>. &nbsp;  Each item consists of <b>two letters</b> -- the primary habitat codes directly to the left and right within 50 m (yards) of each stop -- see <a href="http://www.unc.edu/~rhwiley/mbbs/habitatcodes.html" target="_blank">the instructions for habitat codes</a>.  
+This list includes 20 items separated by <b>commas</b> and ending with a <b>semicolon</b>. &nbsp;  Each item consists of <b>two letters</b> -- the primary habitat codes directly to the left and right within 50 m (yards) of each stop -- see <a href="habitatcodes.html" target="_blank">the instructions for habitat codes</a>.  
 
 <p>              
    
 Any (optional) secondary (or tertiary) habitat codes are placed in parentheses following the corresponding primary habitat code.
 
 <p>              
-   
-<img src="http://www.unc.edu/~rhwiley/gifs/blackpixel.GIF" height=1 width=100%>   
-   
-<p>
 
 <center>
 
@@ -146,10 +138,6 @@ Estimating the proportions of all habitats within hearing range of a stop would 
 
 <p>              
 
-<img src="http://www.unc.edu/~rhwiley/gifs/blackpixel.GIF" height=1   
-width=100%>   
-   
-<p>
 
 </td></tr>
 

--- a/old-mbbs/allhabitats.html
+++ b/old-mbbs/allhabitats.html
@@ -66,10 +66,6 @@ Any (optional) secondary (or tertiary) habitat codes are placed in parentheses f
 
 <p>
 
-See the <a href="http://www.unc.edu/~rhwiley/mbbs/#ebird" target="_blank">basic instructions for the Comments box</a>.
-
-<p>
-
 The draconian instructions about standardized punctuation make it far easier for anyone to download and analyze our surveys.  &nbsp; Provided the format of the punctuation is exactly standardized, a simple computer program can parse the Comments box to recover all the pertinent information.  &nbsp; Otherwise, it would be hell on wheels to make a computer figure out everybody's individual preferences for formatting! &nbsp; So, with that thought in mind ...
 
 <p>


### PR DESCRIPTION
@ahhurlbert I updated the links on the all habitats page. I can't find where this:

```
<a href="http://www.unc.edu/~rhwiley/mbbs/#ebird" target="_blank">basic instructions for the Comments box</a>.
```
 was supposed to link to, so I just removed it.