### PR TITLE
fixes error whereby mean computed incorrectly

### DIFF
--- a/1a_data_prep.R
+++ b/1a_data_prep.R
@@ -18,7 +18,7 @@ pre_dt <-
   ) %>%
   ungroup() %>%
   group_by(
-    mbbs_county, year, common_name, sci_name,  tax_order, date, route_num
+    mbbs_county, year, common_name, sci_name, tax_order, date, route_num
   ) %>%
   summarise(
     count = sum(count)
@@ -42,19 +42,20 @@ analysis_species <- pre_dt %>%
   # include species only observed in at least 3 years
   filter(nyears > 2)
 
-analysis_dt <- pre_dt %>%
-  right_join(analysis_species, by = "common_name") 
+analysis_dt <- 
+  pre_dt %>%
+  right_join(analysis_species, by = "common_name") %>%
+  complete(
+    nesting(sci_name, common_name, route),
+    year = full_seq(year, 1), 
+    fill = list(count = 0)
+  ) 
 
 analysis_dt_grouped <- 
   analysis_dt %>%
   group_by(year, common_name) %>%
   summarise(count = mean(count)) %>%
-  ungroup() %>%
-  complete(
-    nesting(common_name),
-    year = full_seq(year, 1), 
-    fill = list(count = 0)
-  ) 
+  ungroup()
 
 model_dt <- 
   analysis_dt %>%


### PR DESCRIPTION
Yearly means were computed *only among routes where a species was observed*. Hence the denominator could be way off for rare species. This wouldn't have affected common species much.

The difference can be seen in Yellow Warbler (e.g.).

Before fix:

![image](https://user-images.githubusercontent.com/4882990/147796820-f7b9f3fa-37f9-44dc-8687-9e522b34e4f0.png)

After fix: 

![image](https://user-images.githubusercontent.com/4882990/147796848-83f0e64a-829b-4501-82b2-8888978e8234.png)
