### PR TITLE
Add link to data website

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -463,6 +463,14 @@ viewNavigation =
                             ]
                             [ text "Participate" ]
                         ]
+                        
+                    , li [ class "nav-item" ]
+                        [ a
+                            [ class "nav-link"
+                            , href "https://nc-minibbs.github.io/mbbs/"
+                            ]
+                            [ text "Download Data" ]
+                        ]
                     ]
                 ]
             ]


### PR DESCRIPTION
Should add a link at the top of the page to the data website. I followed the template of the 'Participate' link, but not sure how to eg. deploy a draft to see if it works.

EDIT: Oh I see github automatically makes one :D